### PR TITLE
Align external oracle version with the one used by Spring Boot tests

### DIFF
--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalOracleIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalOracleIT.java
@@ -6,6 +6,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ExternalOracleIT extends AbstractExternalSqlDatabaseTest {
     public ExternalOracleIT() {
-        super("oracle12cR2&&geo_BOS", "target/test-classes/project-defaults-external-oracle.yml");
+        super("oracle12c", "target/test-classes/project-defaults-external-oracle.yml");
     }
 }


### PR DESCRIPTION
I thought I used Spring Boot db allocator id before, but seems I didn't actually.

Now it works.