### PR TITLE
Fix sql-db tests. Bump Fabric8 Maven plugin to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,8 @@
         <version.java>1.8</version.java>
 
         <version.com.oracle.jdbc>12.2.0.1</version.com.oracle.jdbc>
-        <version.io.fabric8.fabric8-maven-plugin>4.0.0-M2</version.io.fabric8.fabric8-maven-plugin>
+        <version.com.h2database.h2>1.4.197</version.com.h2database.h2>
+        <version.io.fabric8.fabric8-maven-plugin>4.0.0</version.io.fabric8.fabric8-maven-plugin>
         <version.io.fabric8.openshift-client>4.1.1</version.io.fabric8.openshift-client>
         <version.io.rest-assured>3.1.1</version.io.rest-assured>
         <version.io.thorntail>2.3.0.Final</version.io.thorntail>
@@ -160,6 +161,11 @@
             </dependency>
 
             <!-- JDBC drivers -->
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${version.com.h2database.h2}</version>
+            </dependency>
             <dependency>
                 <groupId>com.oracle.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>

--- a/sql-db/pom.xml
+++ b/sql-db/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
 
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>

--- a/sql-db/src/main/fabric8/configmap.yml
+++ b/sql-db/src/main/fabric8/configmap.yml
@@ -2,3 +2,11 @@ metadata:
   name: app-config
 data:
   project-defaults.yml: |
+    swarm:
+      datasources:
+        data-sources:
+          MyDS:
+            driver-name: h2
+            connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+            user-name: sa
+            password: sa

--- a/sql-db/src/main/fabric8/deployment.yml
+++ b/sql-db/src/main/fabric8/deployment.yml
@@ -3,7 +3,7 @@ spec:
     spec:
       containers:
       - env:
-        - name: JAVA_OPTIONS
+        - name: JAVA_OPTS
           value: "-Dswarm.project.stage.file=file:///app/config/project-defaults.yml"
         volumeMounts:
         - name: config


### PR DESCRIPTION
So it seems that, when deploying sql-db with empty configmap, app wasn't ready so it undeployed and wasn't ready. I added a default h2 datasource so it doesn't complain the first time and deploys succesfully, making possible to be changed by other configmaps later.
