### PR TITLE
refactor SQL database tests

### DIFF
--- a/common/src/main/java/io/thorntail/openshift/ts/common/arquillian/ArquillianExtension.java
+++ b/common/src/main/java/io/thorntail/openshift/ts/common/arquillian/ArquillianExtension.java
@@ -6,6 +6,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 public class ArquillianExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
+        builder.observer(ProjectCleanupObserver.class);
         builder.observer(OpenShiftUtilProducer.class);
         builder.service(ResourceProvider.class, OpenShiftUtilResourceProvider.class);
     }

--- a/common/src/main/java/io/thorntail/openshift/ts/common/arquillian/OpenShiftUtil.java
+++ b/common/src/main/java/io/thorntail/openshift/ts/common/arquillian/OpenShiftUtil.java
@@ -66,7 +66,7 @@ public final class OpenShiftUtil {
         return number;
     }
 
-    public void rolloutChanges(String deploymentConfigName, URL healthUrl) {
+    public void rolloutChanges(String deploymentConfigName, URL awaitUrl) {
         int replicas = countReadyReplicas(deploymentConfigName);
 
         // in reality, user would do `oc rollout latest`, but that's hard (racy) to wait for
@@ -74,18 +74,26 @@ public final class OpenShiftUtil {
         scale(deploymentConfigName, 0);
         scale(deploymentConfigName, replicas);
 
-        ResourceUtil.awaitRoute(healthUrl, 200);
+        ResourceUtil.awaitRoute(awaitUrl, 200);
     }
 
-    public void deployAndRollout(File yaml, String appName, URL healthUrl) throws IOException {
+    public void applyYaml(File yaml) throws IOException {
         try (InputStream is = new FileInputStream(yaml)) {
-            deployAndRollout(is, appName, healthUrl);
+            applyYaml(is);
         }
     }
 
-    public void deployAndRollout(InputStream yaml, String appName, URL healthUrl) {
+    public void applyYaml(InputStream yaml) {
         oc.load(yaml).createOrReplace();
+    }
 
-        rolloutChanges(appName, healthUrl);
+    public void deleteYaml(File yaml) throws IOException {
+        try (InputStream is = new FileInputStream(yaml)) {
+            deleteYaml(is);
+        }
+    }
+
+    public void deleteYaml(InputStream yaml) {
+        oc.load(yaml).delete();
     }
 }

--- a/common/src/main/java/io/thorntail/openshift/ts/common/arquillian/ProjectCleanup.java
+++ b/common/src/main/java/io/thorntail/openshift/ts/common/arquillian/ProjectCleanup.java
@@ -1,0 +1,30 @@
+package io.thorntail.openshift.ts.common.arquillian;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * If a test class is annotated with {@code @ProjectCleanup}, the current OpenShift project will be cleaned up
+ * before the test class is executed. Not all resources are deleted, only resources of these types:
+ *
+ * <ul>
+ *     <li>Deployment</li>
+ *     <li>DeploymentConfig</li>
+ *     <li>ReplicaSet</li>
+ *     <li>ReplicationController</li>
+ *     <li>Pod</li>
+ *     <li>Service</li>
+ *     <li>Route</li>
+ *     <li>Template</li>
+ *     <li>ConfigMap</li>
+ * </ul>
+ *
+ * Resources related to images (such as BuildConfig or ImageStream) are specifically not deleted, because
+ * they are expected to be used for multiple tests.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ProjectCleanup {
+}

--- a/common/src/main/java/io/thorntail/openshift/ts/common/arquillian/ProjectCleanupObserver.java
+++ b/common/src/main/java/io/thorntail/openshift/ts/common/arquillian/ProjectCleanupObserver.java
@@ -1,0 +1,19 @@
+package io.thorntail.openshift.ts.common.arquillian;
+
+import org.arquillian.cube.kubernetes.impl.utils.CommandExecutor;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
+
+import java.util.logging.Logger;
+
+public class ProjectCleanupObserver {
+    private static final Logger log = Logger.getLogger(ProjectCleanupObserver.class.getName());
+
+    public void cleanup(@Observes(precedence = 10_000) BeforeClass event) {
+        if (event.getTestClass().isAnnotationPresent(ProjectCleanup.class)) {
+            log.info("Cleaning current OpenShift project");
+            CommandExecutor cmd = new CommandExecutor();
+            cmd.execCommand("oc", "delete", "deployment,deploymentconfig,replicaset,replicationcontroller,pod,service,route,template,configmap", "--all");
+        }
+    }
+}

--- a/configmap/src/test/java/io/thorntail/openshift/ts/configmap/ConfigMapIT.java
+++ b/configmap/src/test/java/io/thorntail/openshift/ts/configmap/ConfigMapIT.java
@@ -58,7 +58,8 @@ public class ConfigMapIT {
 
     @Test
     public void _3_updateConfigMap() throws Exception {
-        openshift.deployAndRollout(new File("target/test-classes/test-config-update.yml"), APP_NAME, greetingUrl);
+        openshift.applyYaml(new File("target/test-classes/test-config-update.yml"));
+        openshift.rolloutChanges(APP_NAME, greetingUrl);
 
         given()
                 .baseUri(greetingUrl.toString())
@@ -71,7 +72,8 @@ public class ConfigMapIT {
 
     @Test
     public void _4_wrongConfiguration() throws Exception {
-        openshift.deployAndRollout(new File("target/test-classes/test-config-broken.yml"), APP_NAME, healthUrl);
+        openshift.applyYaml(new File("target/test-classes/test-config-broken.yml"));
+        openshift.rolloutChanges(APP_NAME, healthUrl);
 
         await().atMost(5, TimeUnit.MINUTES).untilAsserted(() -> {
             given()

--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,13 @@
         <version.java>1.8</version.java>
 
         <version.com.oracle.jdbc>12.2.0.1</version.com.oracle.jdbc>
-        <version.io.fabric8.fabric8-maven-plugin>4.0.0-M2</version.io.fabric8.fabric8-maven-plugin>
+        <version.io.fabric8.fabric8-maven-plugin>4.0.0</version.io.fabric8.fabric8-maven-plugin>
         <version.io.fabric8.openshift-client>4.1.1</version.io.fabric8.openshift-client>
         <version.io.rest-assured>3.1.1</version.io.rest-assured>
-        <version.io.thorntail>2.3.0.Final</version.io.thorntail>
+        <version.io.thorntail>2.4.1.Final-SNAPSHOT</version.io.thorntail>
         <version.junit.junit>4.12</version.junit.junit>
-        <version.mysql.mysql-connector-java>8.0.11</version.mysql.mysql-connector-java>
+        <!-- it's also good to manually test version 5.1.47 (or latest in the 5.x stream) from time to time -->
+        <version.mysql.mysql-connector-java>8.0.15</version.mysql.mysql-connector-java>
         <version.org.apache.httpcomponents.everything>4.5.6</version.org.apache.httpcomponents.everything>
         <version.org.apache.maven.plugins.maven-compiler-plugin>3.7.0</version.org.apache.maven.plugins.maven-compiler-plugin>
         <version.org.apache.maven.plugins.maven-enforcer.plugin>1.4.1</version.org.apache.maven.plugins.maven-enforcer.plugin>
@@ -47,7 +48,7 @@
         <version.org.assertj.assertj-core>3.9.1</version.org.assertj.assertj-core>
         <version.org.awaitility>3.1.2</version.org.awaitility>
         <version.org.codehaus.mojo.keytool-maven-plugin>1.5</version.org.codehaus.mojo.keytool-maven-plugin>
-        <version.org.postgresql>42.2.4</version.org.postgresql>
+        <version.org.postgresql>42.2.5</version.org.postgresql>
         <version.org.jboss.arquillian>1.4.0.Final</version.org.jboss.arquillian>
         <version.org.jboss.resteasy>3.0.24.Final</version.org.jboss.resteasy>
         <version.org.wildfly.core.wildfly-controller-client>2.2.1.Final</version.org.wildfly.core.wildfly-controller-client>

--- a/sql-db/src/main/fabric8/configmap.yml
+++ b/sql-db/src/main/fabric8/configmap.yml
@@ -1,4 +1,0 @@
-metadata:
-  name: app-config
-data:
-  project-defaults.yml: |

--- a/sql-db/src/main/fabric8/deployment.yml
+++ b/sql-db/src/main/fabric8/deployment.yml
@@ -3,7 +3,7 @@ spec:
     spec:
       containers:
       - env:
-        - name: JAVA_OPTIONS
+        - name: JAVA_OPTS
           value: "-Dswarm.project.stage.file=file:///app/config/project-defaults.yml"
         volumeMounts:
         - name: config

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/AbstractSqlDatabaseTest.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/AbstractSqlDatabaseTest.java
@@ -1,47 +1,21 @@
 package io.thorntail.openshift.ts.sql.db;
 
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.thorntail.openshift.ts.common.arquillian.OpenShiftUtil;
 import org.arquillian.cube.openshift.impl.enricher.AwaitRoute;
 import org.arquillian.cube.openshift.impl.enricher.RouteURL;
-import org.jboss.arquillian.junit.InSequence;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
-
-import java.net.URL;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
 public abstract class AbstractSqlDatabaseTest {
-    protected static final String APP_NAME = System.getProperty("app.name");
-    protected static final String DB_APP_NAME = "test-db";
-
     @RouteURL(value = "${app.name}", path = "/api/sqldb")
-    @AwaitRoute(path = "/health")
-    protected URL url;
-
-    @ArquillianResource
-    protected OpenShiftClient oc;
-
-    @ArquillianResource
-    protected OpenShiftUtil openshift;
-
-    protected abstract void createDb() throws Exception;
-
-    protected abstract void dropDb() throws Exception;
+    @AwaitRoute
+    private String url;
 
     @Test
-    @InSequence(1)
-    public void setUp() throws Exception {
-        createDb();
-    }
-
-    @Test
-    @InSequence(10)
     public void selectOne() {
         given()
-                .baseUri(url.toString())
+                .baseUri(url)
         .when()
                 .get("/select-one")
         .then()
@@ -51,10 +25,9 @@ public abstract class AbstractSqlDatabaseTest {
     }
 
     @Test
-    @InSequence(11)
     public void selectMany() {
         given()
-                .baseUri(url.toString())
+                .baseUri(url)
         .when()
                 .get("/select-many")
         .then()
@@ -63,10 +36,9 @@ public abstract class AbstractSqlDatabaseTest {
     }
 
     @Test
-    @InSequence(12)
     public void update() {
         given()
-                .baseUri(url.toString())
+                .baseUri(url)
         .when()
                 .get("/update")
         .then()
@@ -75,20 +47,13 @@ public abstract class AbstractSqlDatabaseTest {
     }
 
     @Test
-    @InSequence(13)
     public void delete() {
         given()
-                .baseUri(url.toString())
+                .baseUri(url)
         .when()
                 .get("/delete")
         .then()
                 .statusCode(200)
                 .body(containsString("OK"));
-    }
-
-    @Test
-    @InSequence(20)
-    public void tearDown() throws Exception {
-        dropDb();
     }
 }

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalMysqlIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalMysqlIT.java
@@ -1,11 +1,13 @@
 package io.thorntail.openshift.ts.sql.db;
 
+import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMap;
+import io.thorntail.openshift.ts.sql.db.infra.ExternalMysql;
+import org.arquillian.cube.openshift.api.OpenShiftResource;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-public class ExternalMysqlIT extends AbstractExternalSqlDatabaseTest {
-    public ExternalMysqlIT() {
-        super("mysql57&&geo_BOS", "target/test-classes/project-defaults-external-mysql.yml");
-    }
+@SqlDatabaseAndConfigMap(ExternalMysql.class)
+@OpenShiftResource("file:target/classes/META-INF/fabric8/openshift.yml")
+public class ExternalMysqlIT extends AbstractSqlDatabaseTest {
 }

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalMysqlIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalMysqlIT.java
@@ -1,5 +1,6 @@
 package io.thorntail.openshift.ts.sql.db;
 
+import io.thorntail.openshift.ts.common.arquillian.ProjectCleanup;
 import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMap;
 import io.thorntail.openshift.ts.sql.db.infra.ExternalMysql;
 import org.arquillian.cube.openshift.api.OpenShiftResource;
@@ -7,6 +8,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
+@ProjectCleanup
 @SqlDatabaseAndConfigMap(ExternalMysql.class)
 @OpenShiftResource("file:target/classes/META-INF/fabric8/openshift.yml")
 public class ExternalMysqlIT extends AbstractSqlDatabaseTest {

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalOracleIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalOracleIT.java
@@ -1,11 +1,13 @@
 package io.thorntail.openshift.ts.sql.db;
 
+import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMap;
+import io.thorntail.openshift.ts.sql.db.infra.ExternalOracle;
+import org.arquillian.cube.openshift.api.OpenShiftResource;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-public class ExternalOracleIT extends AbstractExternalSqlDatabaseTest {
-    public ExternalOracleIT() {
-        super("oracle12c", "target/test-classes/project-defaults-external-oracle.yml");
-    }
+@SqlDatabaseAndConfigMap(ExternalOracle.class)
+@OpenShiftResource("file:target/classes/META-INF/fabric8/openshift.yml")
+public class ExternalOracleIT extends AbstractSqlDatabaseTest {
 }

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalOracleIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalOracleIT.java
@@ -1,5 +1,6 @@
 package io.thorntail.openshift.ts.sql.db;
 
+import io.thorntail.openshift.ts.common.arquillian.ProjectCleanup;
 import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMap;
 import io.thorntail.openshift.ts.sql.db.infra.ExternalOracle;
 import org.arquillian.cube.openshift.api.OpenShiftResource;
@@ -7,6 +8,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
+@ProjectCleanup
 @SqlDatabaseAndConfigMap(ExternalOracle.class)
 @OpenShiftResource("file:target/classes/META-INF/fabric8/openshift.yml")
 public class ExternalOracleIT extends AbstractSqlDatabaseTest {

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalPostgresqlIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalPostgresqlIT.java
@@ -1,5 +1,6 @@
 package io.thorntail.openshift.ts.sql.db;
 
+import io.thorntail.openshift.ts.common.arquillian.ProjectCleanup;
 import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMap;
 import io.thorntail.openshift.ts.sql.db.infra.ExternalPostgresql;
 import org.arquillian.cube.openshift.api.OpenShiftResource;
@@ -7,6 +8,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
+@ProjectCleanup
 @SqlDatabaseAndConfigMap(ExternalPostgresql.class)
 @OpenShiftResource("file:target/classes/META-INF/fabric8/openshift.yml")
 public class ExternalPostgresqlIT extends AbstractSqlDatabaseTest {

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalPostgresqlIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/ExternalPostgresqlIT.java
@@ -1,11 +1,13 @@
 package io.thorntail.openshift.ts.sql.db;
 
+import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMap;
+import io.thorntail.openshift.ts.sql.db.infra.ExternalPostgresql;
+import org.arquillian.cube.openshift.api.OpenShiftResource;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-public class ExternalPostgresqlIT extends AbstractExternalSqlDatabaseTest {
-    public ExternalPostgresqlIT() {
-        super("postgresql96&&geo_RDU", "target/test-classes/project-defaults-external-postgresql.yml");
-    }
+@SqlDatabaseAndConfigMap(ExternalPostgresql.class)
+@OpenShiftResource("file:target/classes/META-INF/fabric8/openshift.yml")
+public class ExternalPostgresqlIT extends AbstractSqlDatabaseTest {
 }

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/MysqlIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/MysqlIT.java
@@ -1,21 +1,13 @@
 package io.thorntail.openshift.ts.sql.db;
 
+import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMap;
+import io.thorntail.openshift.ts.sql.db.infra.Mysql;
+import org.arquillian.cube.openshift.api.OpenShiftResource;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
-import java.io.File;
-
 @RunWith(Arquillian.class)
-public class MysqlIT extends AbstractInternalSqlDatabaseTest {
-    public MysqlIT() {
-        super(
-                "registry.access.redhat.com/rhscl/mysql-57-rhel7",
-                new File("target/test-classes/project-defaults-mysql.yml"),
-                mapOf(
-                        "MYSQL_DATABASE", "testdb",
-                        "MYSQL_USER", "testuser",
-                        "MYSQL_PASSWORD", "password"
-                )
-        );
-    }
+@SqlDatabaseAndConfigMap(Mysql.class)
+@OpenShiftResource("file:target/classes/META-INF/fabric8/openshift.yml")
+public class MysqlIT extends AbstractSqlDatabaseTest {
 }

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/MysqlIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/MysqlIT.java
@@ -1,5 +1,6 @@
 package io.thorntail.openshift.ts.sql.db;
 
+import io.thorntail.openshift.ts.common.arquillian.ProjectCleanup;
 import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMap;
 import io.thorntail.openshift.ts.sql.db.infra.Mysql;
 import org.arquillian.cube.openshift.api.OpenShiftResource;
@@ -7,6 +8,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
+@ProjectCleanup
 @SqlDatabaseAndConfigMap(Mysql.class)
 @OpenShiftResource("file:target/classes/META-INF/fabric8/openshift.yml")
 public class MysqlIT extends AbstractSqlDatabaseTest {

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/PostgresqlIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/PostgresqlIT.java
@@ -1,21 +1,13 @@
 package io.thorntail.openshift.ts.sql.db;
 
+import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMap;
+import io.thorntail.openshift.ts.sql.db.infra.Postgresql;
+import org.arquillian.cube.openshift.api.OpenShiftResource;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
-import java.io.File;
-
 @RunWith(Arquillian.class)
-public class PostgresqlIT extends AbstractInternalSqlDatabaseTest {
-    public PostgresqlIT() {
-        super(
-                "registry.access.redhat.com/rhscl/postgresql-95-rhel7",
-                new File("target/test-classes/project-defaults-postgresql.yml"),
-                mapOf(
-                        "POSTGRESQL_DATABASE", "testdb",
-                        "POSTGRESQL_USER", "testuser",
-                        "POSTGRESQL_PASSWORD", "password"
-                )
-        );
-    }
+@SqlDatabaseAndConfigMap(Postgresql.class)
+@OpenShiftResource("file:target/classes/META-INF/fabric8/openshift.yml")
+public class PostgresqlIT extends AbstractSqlDatabaseTest {
 }

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/PostgresqlIT.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/PostgresqlIT.java
@@ -1,5 +1,6 @@
 package io.thorntail.openshift.ts.sql.db;
 
+import io.thorntail.openshift.ts.common.arquillian.ProjectCleanup;
 import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMap;
 import io.thorntail.openshift.ts.sql.db.infra.Postgresql;
 import org.arquillian.cube.openshift.api.OpenShiftResource;
@@ -7,6 +8,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
+@ProjectCleanup
 @SqlDatabaseAndConfigMap(Postgresql.class)
 @OpenShiftResource("file:target/classes/META-INF/fabric8/openshift.yml")
 public class PostgresqlIT extends AbstractSqlDatabaseTest {

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/arquillian/SqlDatabaseAndConfigMap.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/arquillian/SqlDatabaseAndConfigMap.java
@@ -1,0 +1,12 @@
+package io.thorntail.openshift.ts.sql.db.arquillian;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface SqlDatabaseAndConfigMap {
+    Class<? extends SqlDatabaseAndConfigMapStrategy> value();
+}

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/arquillian/SqlDatabaseAndConfigMapExtension.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/arquillian/SqlDatabaseAndConfigMapExtension.java
@@ -1,0 +1,52 @@
+package io.thorntail.openshift.ts.sql.db.arquillian;
+
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.event.suite.AfterClass;
+import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
+import org.jboss.arquillian.test.spi.event.suite.ClassLifecycleEvent;
+
+import java.util.logging.Logger;
+
+public class SqlDatabaseAndConfigMapExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.observer(SqlDatabaseAndConfigMapDeployer.class);
+    }
+
+    private static class SqlDatabaseAndConfigMapDeployer {
+        private static final Logger log = Logger.getLogger(SqlDatabaseAndConfigMapDeployer.class.getName());
+
+        @Inject
+        private Instance<Injector> injector;
+
+        // precedence of these observers must be higher than the precedence of @OpenShiftResource observers
+        // in Arquillian Cube, because the database must be deployed sooner / undeployed after the app
+        // (which is deployed/undeployed using @OpenShiftResource)
+
+        public void deploy(@Observes(precedence = 1000) BeforeClass event) throws Exception {
+            SqlDatabaseAndConfigMapStrategy strategy = strategy(event);
+            log.info("Deploying " + strategy.getClass().getName());
+            strategy.deploy();
+        }
+
+        public void undeploy(@Observes(precedence = 1000) AfterClass event) throws Exception {
+            SqlDatabaseAndConfigMapStrategy strategy = strategy(event);
+            log.info("Undeploying " + strategy.getClass().getName());
+            strategy.undeploy();
+        }
+
+        private SqlDatabaseAndConfigMapStrategy strategy(ClassLifecycleEvent event) throws ReflectiveOperationException {
+            if (event.getTestClass().isAnnotationPresent(SqlDatabaseAndConfigMap.class)) {
+                Class<? extends SqlDatabaseAndConfigMapStrategy> maintainer = event.getTestClass().getAnnotation(SqlDatabaseAndConfigMap.class).value();
+                SqlDatabaseAndConfigMapStrategy instance = maintainer.newInstance();
+                return injector.get().inject(instance);
+            }
+
+            return SqlDatabaseAndConfigMapStrategy.NOOP;
+        }
+    }
+}

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/arquillian/SqlDatabaseAndConfigMapStrategy.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/arquillian/SqlDatabaseAndConfigMapStrategy.java
@@ -1,0 +1,17 @@
+package io.thorntail.openshift.ts.sql.db.arquillian;
+
+public interface SqlDatabaseAndConfigMapStrategy {
+    void deploy() throws Exception;
+
+    void undeploy() throws Exception;
+
+    SqlDatabaseAndConfigMapStrategy NOOP = new SqlDatabaseAndConfigMapStrategy() {
+        @Override
+        public void deploy() {
+        }
+
+        @Override
+        public void undeploy() {
+        }
+    };
+}

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/AbstractExternalSqlDatabaseAndConfigMapStrategy.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/AbstractExternalSqlDatabaseAndConfigMapStrategy.java
@@ -1,4 +1,4 @@
-package io.thorntail.openshift.ts.sql.db;
+package io.thorntail.openshift.ts.sql.db.infra;
 
 import io.thorntail.openshift.ts.common.db.allocator.DbAllocation;
 import io.thorntail.openshift.ts.common.db.allocator.DbAllocator;
@@ -9,33 +9,36 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-public abstract class AbstractExternalSqlDatabaseTest extends AbstractSqlDatabaseTest {
+public abstract class AbstractExternalSqlDatabaseAndConfigMapStrategy extends AbstractSqlDatabaseAndConfigMapStrategy {
     private static final DbAllocator DB_ALLOCATOR = new DbAllocator(System.getProperty("db.allocator.url"));
 
     private final String dbAllocatorLabel;
     private final String projectDefaultsYmlPath;
 
     private static DbAllocation allocatedDb; // static because each test gets its own instance of this class :-(
+    private static String configMapContent;
 
-    protected AbstractExternalSqlDatabaseTest(String dbAllocatorLabel, String projectDefaultsYmlPath) {
+    protected AbstractExternalSqlDatabaseAndConfigMapStrategy(String dbAllocatorLabel, String projectDefaultsYmlPath) {
         this.dbAllocatorLabel = dbAllocatorLabel;
         this.projectDefaultsYmlPath = projectDefaultsYmlPath;
     }
 
     @Override
-    protected void createDb() throws Exception {
+    public void deploy() throws Exception {
         allocatedDb = DB_ALLOCATOR.allocate(dbAllocatorLabel);
 
-        String config = new String(Files.readAllBytes(Paths.get(projectDefaultsYmlPath)), StandardCharsets.UTF_8)
+        configMapContent = new String(Files.readAllBytes(Paths.get(projectDefaultsYmlPath)), StandardCharsets.UTF_8)
                 .replace("${db.jdbc.url}", allocatedDb.getJdbcUrl())
                 .replace("${db.username}", allocatedDb.getUsername())
                 .replace("${db.password}", allocatedDb.getPassword());
-        InputStream configInputStream = new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8));
-        openshift.deployAndRollout(configInputStream, APP_NAME, url);
+        InputStream configMapInputStream = new ByteArrayInputStream(configMapContent.getBytes(StandardCharsets.UTF_8));
+        openshift().applyYaml(configMapInputStream);
     }
 
     @Override
-    protected void dropDb() throws Exception {
+    public void undeploy() throws Exception {
+        InputStream configMapInputStream = new ByteArrayInputStream(configMapContent.getBytes(StandardCharsets.UTF_8));
+        openshift().deleteYaml(configMapInputStream);
         DB_ALLOCATOR.free(allocatedDb);
     }
 }

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/AbstractInternalSqlDatabaseAndConfigMapStrategy.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/AbstractInternalSqlDatabaseAndConfigMapStrategy.java
@@ -1,22 +1,24 @@
-package io.thorntail.openshift.ts.sql.db;
+package io.thorntail.openshift.ts.sql.db.infra;
 
 import org.arquillian.cube.kubernetes.impl.utils.CommandExecutor;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class AbstractInternalSqlDatabaseTest extends AbstractSqlDatabaseTest {
+public abstract class AbstractInternalSqlDatabaseAndConfigMapStrategy extends AbstractSqlDatabaseAndConfigMapStrategy {
     private final String image;
     private final File projectDefaultsYml;
     private final Map<String, String> environmentVariables;
 
     private final CommandExecutor cmd;
 
-    protected AbstractInternalSqlDatabaseTest(String image, File projectDefaultsYml, Map<String, String> environmentVariables) {
+    protected AbstractInternalSqlDatabaseAndConfigMapStrategy(String image, File projectDefaultsYml,
+                                                              Map<String, String> environmentVariables) {
         this.image = image;
         this.projectDefaultsYml = projectDefaultsYml;
         this.environmentVariables = environmentVariables;
@@ -25,8 +27,8 @@ public abstract class AbstractInternalSqlDatabaseTest extends AbstractSqlDatabas
     }
 
     @Override
-    public void createDb() throws Exception {
-        cmd.execCommand("oc", "project", oc.getNamespace());
+    public void deploy() throws IOException {
+        cmd.execCommand("oc", "project", oc().getNamespace());
 
         List<String> createDbCommand = new ArrayList<>(Arrays.asList("oc", "new-app", image));
         for (Map.Entry<String, String> environmentVariable : environmentVariables.entrySet()) {
@@ -37,12 +39,13 @@ public abstract class AbstractInternalSqlDatabaseTest extends AbstractSqlDatabas
 
         cmd.execCommand(createDbCommand.toArray(new String[0]));
 
-        openshift.awaitDeploymentReadiness(DB_APP_NAME, 1);
-        openshift.deployAndRollout(projectDefaultsYml, APP_NAME, url);
+        openshift().awaitDeploymentReadiness(DB_APP_NAME, 1);
+        openshift().applyYaml(projectDefaultsYml);
     }
 
     @Override
-    public void dropDb() {
+    public void undeploy() throws IOException {
+        openshift().deleteYaml(projectDefaultsYml);
         cmd.execCommand("oc", "delete", "all", "-l", "app=" + DB_APP_NAME);
     }
 

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/AbstractSqlDatabaseAndConfigMapStrategy.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/AbstractSqlDatabaseAndConfigMapStrategy.java
@@ -1,0 +1,26 @@
+package io.thorntail.openshift.ts.sql.db.infra;
+
+import io.fabric8.kubernetes.clnt.v4_0.KubernetesClient;
+import io.fabric8.openshift.clnt.v4_0.OpenShiftClient;
+import io.thorntail.openshift.ts.common.arquillian.OpenShiftUtil;
+import io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMapStrategy;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+
+public abstract class AbstractSqlDatabaseAndConfigMapStrategy implements SqlDatabaseAndConfigMapStrategy {
+    protected static final String DB_APP_NAME = "test-db";
+
+    @Inject
+    private Instance<KubernetesClient> kubernetesClient;
+
+    @Inject
+    private Instance<OpenShiftUtil> openShiftUtil;
+
+    protected final OpenShiftClient oc() {
+        return kubernetesClient.get().adapt(OpenShiftClient.class);
+    }
+
+    protected final OpenShiftUtil openshift() {
+        return openShiftUtil.get();
+    }
+}

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/ExternalMysql.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/ExternalMysql.java
@@ -1,0 +1,7 @@
+package io.thorntail.openshift.ts.sql.db.infra;
+
+public class ExternalMysql extends AbstractExternalSqlDatabaseAndConfigMapStrategy {
+    public ExternalMysql() {
+        super("mysql57&&geo_BOS", "target/test-classes/project-defaults-external-mysql.yml");
+    }
+}

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/ExternalOracle.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/ExternalOracle.java
@@ -1,0 +1,7 @@
+package io.thorntail.openshift.ts.sql.db.infra;
+
+public class ExternalOracle extends AbstractExternalSqlDatabaseAndConfigMapStrategy {
+    public ExternalOracle() {
+        super("oracle12c", "target/test-classes/project-defaults-external-oracle.yml");
+    }
+}

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/ExternalPostgresql.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/ExternalPostgresql.java
@@ -1,0 +1,7 @@
+package io.thorntail.openshift.ts.sql.db.infra;
+
+public class ExternalPostgresql extends AbstractExternalSqlDatabaseAndConfigMapStrategy {
+    public ExternalPostgresql() {
+        super("postgresql96&&geo_RDU", "target/test-classes/project-defaults-external-postgresql.yml");
+    }
+}

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/Mysql.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/Mysql.java
@@ -1,0 +1,17 @@
+package io.thorntail.openshift.ts.sql.db.infra;
+
+import java.io.File;
+
+public class Mysql extends AbstractInternalSqlDatabaseAndConfigMapStrategy {
+    public Mysql() {
+        super(
+                "registry.access.redhat.com/rhscl/mysql-57-rhel7",
+                new File("target/test-classes/project-defaults-mysql.yml"),
+                mapOf(
+                        "MYSQL_DATABASE", "testdb",
+                        "MYSQL_USER", "testuser",
+                        "MYSQL_PASSWORD", "password"
+                )
+        );
+    }
+}

--- a/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/Postgresql.java
+++ b/sql-db/src/test/java/io/thorntail/openshift/ts/sql/db/infra/Postgresql.java
@@ -1,0 +1,17 @@
+package io.thorntail.openshift.ts.sql.db.infra;
+
+import java.io.File;
+
+public class Postgresql extends AbstractInternalSqlDatabaseAndConfigMapStrategy {
+    public Postgresql() {
+        super(
+                "registry.access.redhat.com/rhscl/postgresql-95-rhel7",
+                new File("target/test-classes/project-defaults-postgresql.yml"),
+                mapOf(
+                        "POSTGRESQL_DATABASE", "testdb",
+                        "POSTGRESQL_USER", "testuser",
+                        "POSTGRESQL_PASSWORD", "password"
+                )
+        );
+    }
+}

--- a/sql-db/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/sql-db/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+io.thorntail.openshift.ts.sql.db.arquillian.SqlDatabaseAndConfigMapExtension

--- a/sql-db/src/test/resources/arquillian.xml
+++ b/sql-db/src/test/resources/arquillian.xml
@@ -6,6 +6,8 @@
         <property name="namespace.use.current">true</property>
         <!-- when switching namespace.use.current to false, switch enableImageStreamDetection to true -->
         <property name="enableImageStreamDetection">false</property>
-        <property name="env.init.enabled">true</property>
+
+        <!-- disable this and deploy everything using annotations to get control over deployment ordering -->
+        <property name="env.init.enabled">false</property>
     </extension>
 </arquillian>


### PR DESCRIPTION
Previously, the SQL database was deployed _after_ the testing
application, which is wrong. It used to work, but it no longer
does, so it's time to fix it.

This commit introduces a special Arquillian extension that
observes the `BeforeClass` and `AfterClass` events (that is,
events fired by Arquillian just before/after tests from a single
class are executed) and deploy/undeploy the database at that
point in time.

That requires switching off automatic application deployment
during Arquillian Cube initialization. Instead, application
is deployed using the `@OpenShiftResource` annotation. That
annotation is also implemented using a `Before/AfterClass`
observer, so it's important to make sure that the database
deployment observer runs sooner.

A little bit of code cleanup elsewhere is also included.