### PR TITLE
[ENTSWM-911] topology RoleBinding authorization.openshift.io/v1

### DIFF
--- a/topology/tests/src/main/fabric8/rolebinding.yml
+++ b/topology/tests/src/main/fabric8/rolebinding.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: authorization.openshift.io/v1
 kind: RoleBinding
 metadata:
   name: view-default


### PR DESCRIPTION
When using newer version of Arquillian Cube with v4_10 Kubernetes Client there appeared failure:
No resource type found for:v1#RoleBinding
When using: rbac.authorization.k8s.io/v1 the result was also bad:
RuntimeException: io.fabric8.kubernetes.clnt.v4_10.KubernetesClientException: Failure executing: POST at: https://api.ocp4.dynamic.rhoar:6443/apis/rbac.authorization.k8s.io/v1/namespaces/pene/rolebindings. Message: unsupported role reference kind: "". Received status: Status(apiVersion=v1, code=500, details=null, kind=Status, message=unsupported role reference kind: "", metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=null, status=Failure, additionalProperties={}).

So I tried https://docs.openshift.com/container-platform/4.5/rest_api/role_apis/rolebinding-authorization-openshift-io-v1.html using
authorization.openshift.io/v1 and this succeeded on OCP 3.11, OCP 4.5 and with newer Arquillian Cube on OCP 4.6.
