### PR TITLE
profile all and interop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,20 +10,37 @@
 
     <name>Thorntail OpenShift TS: Parent</name>
 
-    <modules>
-        <module>common</module>
+    <profiles>
+        <profile>
+            <id>all</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>common</module>
 
-        <module>http</module>
-        <module>health-check</module>
-        <module>configmap</module>
+                <module>http</module>
+                <module>health-check</module>
+                <module>configmap</module>
 
-        <module>sql-db</module>
+                <module>sql-db</module>
 
-        <module>topology</module>
-        <module>ssl-passthrough</module>
-        <module>scaling</module>
-        <module>rolling</module>
-    </modules>
+                <module>topology</module>
+                <module>ssl-passthrough</module>
+                <module>scaling</module>
+                <module>rolling</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>interop</id>
+            <modules>
+                <module>common</module>
+
+                <module>http</module>
+            </modules>
+        </profile>
+    </profiles>
+
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
As part of https://projects.engineering.redhat.com/browse/INTEROP-2659 there are two new profiles. Profile "all" is default and contains all modules, profile "interop" has reduced set of modules.
It is expected that Interop Team will use profile "-Pinterop" to trigger reduced set of tests. It is not yet decided how and what branch, therefore **this PR is just a draft!**